### PR TITLE
Zoom to draw layer

### DIFF
--- a/browser/modules/draw.js
+++ b/browser/modules/draw.js
@@ -38,7 +38,9 @@ module.exports = {
     },
 
     init: () => {
-
+        $("#_draw_zoom_btn").on('click', ()=> {
+            _self.zoomToLayer();
+        });
         $("#_draw_download_geojson").click(function () {
             _self.download();
         });
@@ -130,7 +132,13 @@ module.exports = {
             }
         }());
     },
-
+    zoomToLayer : () => {
+      const items=  _self.getDrawItems();
+      if (!items) 
+        return;
+      const bounds= items.getBounds();
+      cloud.get().map.fitBounds(bounds,true);
+    },	
     makeConflictSearchWithSelected: () => {
         if (!selectedDrawing) {
             alert("Vælg en tegning")

--- a/public/templates/standard/default.tmpl
+++ b/public/templates/standard/default.tmpl
@@ -419,6 +419,9 @@
 
                                     </div>
                                 </div>
+                                <button id="_draw_zoom_btn" class="btn btn-sm btn-raised" title="Zoom" style="display:inline" target="_blank" href="javascript:void(0)">
+                                    <i class="fa fa-search-plus" style="font-size:18px"></i> 
+                                </button>
                                 <button class="btn btn-sm btn-raised" id="_draw_download_geojson" target="_blank" href="javascript:void(0)">
                                     <i class="fa fa-download" aria-hidden="true"></i> GeoJson
                                 </button>


### PR DESCRIPTION
new zoom button in the draw panel. Next to GeoJson download and the shape upload. (in another pr)
This set the current zoom the bounds of items in the drawing layer.

This can be helpful, when uploading a shape file, but dont known the location of the geometry - or likewise to get back the current active items in the drawing layer.
