### PR TITLE
toggle raster layer group fix

### DIFF
--- a/browser/modules/layerTree/index.js
+++ b/browser/modules/layerTree/index.js
@@ -4115,10 +4115,10 @@ module.exports = {
         const activeLayers = _self.getActiveLayers().filter(e => {
             // If the activeLayer has prefix, strip it
             // split string on first ':' and keep only the second part
-            e = e.split(':').slice(1).join(':');
+            e = (e.startsWith('v:')) ? e.split(':').slice(1).join(':'): e;
             console.log(e);
             return metaDataKeys[e]?.layergroup === layerGroup
-    });
+        });
         const activeLayersInGroup = activeLayers.length;
         if (layerSubGroup) {
             let split = layerSubGroup.split('|');


### PR DESCRIPTION
Fixing layergroup toggling. Internal layer key is prefixed with 'v:' when its a vector layer, while the metadata layer key is not. This logic was not correct when counting number of layers turned on or off